### PR TITLE
More documentation for obscure functions

### DIFF
--- a/cpux86-ta.js
+++ b/cpux86-ta.js
@@ -4862,21 +4862,21 @@ CPU_X86.prototype.exec_internal = function(N_cycles, interrupt) {
         _op = 24;
     }
     function op_CPUID() {
-        var Rb;
-        Rb = regs[0];
-        switch (Rb) {
-            case 0:
+        var eax;
+        eax = regs[0];
+        switch (eax) {
+            case 0:  // eax == 0: vendor ID
                 regs[0] = 1;
                 regs[3] = 0x756e6547 & -1;
                 regs[2] = 0x49656e69 & -1;
                 regs[1] = 0x6c65746e & -1;
                 break;
-            case 1:
+            case 1:  // eax == 1: processor info and feature flags
             default:
-                regs[0] = (5 << 8) | (4 << 4) | 3;
-                regs[3] = 8 << 8;
+                regs[0] = (5 << 8) | (4 << 4) | 3; // family | model | stepping
+                regs[3] = 8 << 8;                  // danluu: This is a mystery to me. This bit now indicates clflush line size, but must have meant something else in the past.
                 regs[1] = 0;
-                regs[2] = (1 << 4);
+                regs[2] = (1 << 4);                // rdtsc support
                 break;
         }
     }

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,8 @@ have been added.
 The core opcode execution loop has been autocommented to indicate what
 instruction operation the opcode refers to.
 
+One mystery is, why does CPUID(1) return 8 << 8 in EBX? EBX[15:8] is now used to indicate CLFLUSH line size, but that field must have been used for something else in the past.
+
 ### ETC
 
 I highly recommend, by the way, the excellent [JSShaper][2] library for transforming large javascript code bases.  The hacks I made from it are in this repo: a little symbol-name-transformer node.js script and an emacs function for doing this in live buffers.


### PR DESCRIPTION
I was going to batch up a bunch of these, like last time, but I ran into something I couldn't figure out; perhaps it's obvious to you, or someone else.

In particular, I don't understand this block:

``` C
            case 1:  // eax == 1: processor info and feature flags
            default:
                regs[0] = (5 << 8) | (4 << 4) | 3; // family | model | stepping
                regs[3] = 8 << 8; // ???????  
                regs[1] = 0;
                regs[2] = (1 << 4); // rdtsc support
                break;
```

If I'm reading it correctly, the line labeled `???????` sets a bit that would, on a modern processor, indicate the CLFLUSH line size. AFAIK, that wouldn't apply to a 486. Did that bit used to mean something else in the distant past?
